### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Remoteidsync/Form/Settings.php
+++ b/CRM/Remoteidsync/Form/Settings.php
@@ -20,7 +20,7 @@ class CRM_Remoteidsync_Form_Settings extends CRM_Core_Form {
         'api.CustomField.getsingle' => ['custom_group_id' => "\$value.id", 'name' => "Remote_Id"],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error: %1', array(1 => $error, 'domain' => 'com.aghstrategies.remoteidsync')));
     }
@@ -77,7 +77,7 @@ class CRM_Remoteidsync_Form_Settings extends CRM_Core_Form {
         'return' => array_keys($settingFields),
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error: %1', array(1 => $error, 'domain' => 'com.aghstrategies.remoteidsync')));
     }
@@ -118,7 +118,7 @@ class CRM_Remoteidsync_Form_Settings extends CRM_Core_Form {
         $existingSetting = civicrm_api3('Setting', 'create', $params);
         CRM_Core_Session::setStatus(ts('Settings Successfully Saved'), ts('Remote ID Sync'), 'success');
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(
           ts('API Error: %1', array(1 => $error, 'domain' => 'com.aghstrategies.remoteidsync'))

--- a/remoteidsync.php
+++ b/remoteidsync.php
@@ -21,7 +21,7 @@ function remoteidsync_civicrm_summary($contactID, &$content, &$contentPlacement)
         'sequential' => 1,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.remoteidsync',
@@ -213,7 +213,7 @@ function remoteidsync_civicrm_install() {
       'name' => 'Remote_ID',
     ]);
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     $error = $e->getMessage();
     CRM_Core_Error::debug_log_message(ts('API Error %1', array(
       'domain' => 'com.aghstrategies.remoteidsync',
@@ -233,7 +233,7 @@ function remoteidsync_civicrm_install() {
         'extends' => "Contact",
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.remoteidsync',
@@ -258,7 +258,7 @@ function remoteidsync_civicrm_install() {
         // "text_length" => "255",
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.remoteidsync',
@@ -278,7 +278,7 @@ function remoteidsync_civicrm_install() {
           "text_length" => "255",
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(ts('API Error %1', array(
           'domain' => 'com.aghstrategies.remoteidsync',


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.